### PR TITLE
Enable github action ci and CodeQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
+      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,16 @@ jobs:
       - name: Build with Maven
         env:
           MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
-        run: mvn -B package --file pom.xml
+        run: |
+          env
+          mvn -B package --file pom.xml
 
       - name: Run tests with Maven
         env:
           MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"      
-        run: mvn -B test --file pom.xml
+        run: |
+          env
+          mvn -B test --file pom.xml
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: maven
 
       - name: Build with Maven

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '17', '21' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
+      - name: Set MAVEN_OPTS
+        run: echo "MAVEN_OPTS=--add-opens java.base/java.lang=ALL-UNNAMED" >> $GITHUB_ENV
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -32,14 +29,10 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: |
-          echo "MAVEN_OPTS=$MAVEN_OPTS"
-          mvn -B package --file pom.xml
+        run: mvn -B package --file pom.xml
 
       - name: Run tests with Maven
-        run: |
-          echo "MAVEN_OPTS=$MAVEN_OPTS"
-          mvn -B test --file pom.xml
+        run: mvn -B test --file pom.xml
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
+      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'corretto'
+          distribution: 'temurin'
           cache: maven
 
       - name: Build with Maven

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -32,10 +29,10 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" mvn -B package --file pom.xml
 
       - name: Run tests with Maven
-        run: mvn -B test --file pom.xml
+        run: MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" mvn -B test --file pom.xml
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Run tests with Maven
+        run: mvn -B test --file pom.xml
+
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21', '23' ]
+        java: [ '8', '11', '17', '21' ]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -27,8 +30,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-      - name: Set MAVEN_OPTS
-        run: echo "MAVEN_OPTS=--add-opens java.base/java.lang=ALL-UNNAMED" >> $GITHUB_ENV
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,5 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-          cache: maven
       - name: Run tests with Maven
         run: mvn -B test --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '11', '17' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,3 @@ jobs:
 
       - name: Run tests with Maven
         run: mvn -B test --file pom.xml
-
-      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-      - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '11', '17', '21', '23' ]
 
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
-
-      - name: Build with Maven
-        run: mvn -B package --file pom.xml
-
       - name: Run tests with Maven
         run: mvn -B test --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" mvn -B package --file pom.xml
+        env:
+          MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
+        run: mvn -B package --file pom.xml
 
       - name: Run tests with Maven
-        run: MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" mvn -B test --file pom.xml
+        env:
+          MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"      
+        run: mvn -B test --file pom.xml
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -29,17 +32,13 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        env:
-          MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"
         run: |
-          env
+          echo "MAVEN_OPTS=$MAVEN_OPTS"
           mvn -B package --file pom.xml
 
       - name: Run tests with Maven
-        env:
-          MAVEN_OPTS: "--add-opens java.base/java.lang=ALL-UNNAMED"      
         run: |
-          env
+          echo "MAVEN_OPTS=$MAVEN_OPTS"
           mvn -B test --file pom.xml
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "develop", "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "develop", "master" ]
 
 permissions:
   contents: read

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-jdk:
-  - openjdk8

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ JOLT (Community Edition)
 
 JSON to JSON transformation library written in Java where the "specification" for the transform is itself a JSON document.
 
+[![CI](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml/badge.svg)](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml)
+
 ### Community Edition
 This repository is a community-maintained fork of JOLT. For the original version, please visit the [bazaarvoice/jolt](https://github.com/bazaarvoice/jolt) repository.
 

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -49,21 +50,31 @@
         </dependency>
 
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <argLine>
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-                        --add-opens java.base/java.security=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+
+    <profiles>
+        <!-- Profile for non-JDK 8 -->
+        <profile>
+            <id>non-jdk8</id>
+            <activation>
+                <jdk>!1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <configuration>
+                            <argLine>
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                                --add-opens java.base/java.security=ALL-UNNAMED
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -51,30 +51,21 @@
 
     </dependencies>
 
-    <profiles>
-        <!-- Profile for non-JDK 8 -->
-        <profile>
-            <id>non-jdk8</id>
-            <activation>
-                <jdk>!1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <configuration>
-                            <argLine>
-                                --add-opens java.base/java.lang=ALL-UNNAMED
-                                --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-                                --add-opens java.base/java.security=ALL-UNNAMED
-                                --add-opens java.base/java.util=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.security=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -49,5 +49,21 @@
         </dependency>
 
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.security=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/cardinality/CardinalityCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/cardinality/CardinalityCompositeSpec.java
@@ -159,7 +159,7 @@ public class CardinalityCompositeSpec extends CardinalitySpec {
         // Handle the rest of the children
         process( input, walkedPath );
 
-        walkedPath.removeLast();
+        walkedPath.removeLastElement();
         return true;
     }
 

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/cardinality/CardinalityLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/cardinality/CardinalityLeafSpec.java
@@ -122,7 +122,7 @@ public class CardinalityLeafSpec extends CardinalitySpec {
             }
         }
 
-        walkedPath.removeLast();
+        walkedPath.removeLastElement();
 
         return returnValue;
     }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/common/tree/WalkedPath.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/common/tree/WalkedPath.java
@@ -54,10 +54,6 @@ public class WalkedPath extends ArrayList<PathStep> {
         return super.add( new PathStep( treeRef, matchedElement ) );
     }
 
-    public void removeLast() {
-        remove(size() - 1);
-    }
-
     /**
      * Method useful to "&", "&1", "&2", etc evaluation.
      */

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/common/tree/WalkedPath.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/common/tree/WalkedPath.java
@@ -54,6 +54,10 @@ public class WalkedPath extends ArrayList<PathStep> {
         return super.add( new PathStep( treeRef, matchedElement ) );
     }
 
+    public PathStep removeLastElement() {
+        return remove(size() - 1);
+    }
+
     /**
      * Method useful to "&", "&1", "&2", etc evaluation.
      */

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/spec/ModifierCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/spec/ModifierCompositeSpec.java
@@ -175,7 +175,7 @@ public class ModifierCompositeSpec extends ModifierSpec implements OrderedCompos
         // Handle the rest of the children
         executionStrategy.process( this, inputOptional, walkedPath, null, context );
         // We are done, so remove ourselves from the walkedPath
-        walkedPath.removeLast();
+        walkedPath.removeLastElement();
     }
 
     @Override

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/spec/ModifierLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/spec/ModifierLeafSpec.java
@@ -81,7 +81,7 @@ public class ModifierLeafSpec extends ModifierSpec {
             setData( parent, thisLevel, valueOptional.get(), opMode );
         }
 
-        walkedPath.removeLast();
+        walkedPath.removeLastElement();
     }
 
     private static FunctionEvaluator buildFunctionEvaluator( final String rhs, final Map<String, Function> functionsMap ) {

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrCompositeSpec.java
@@ -222,7 +222,7 @@ public class ShiftrCompositeSpec extends ShiftrSpec implements OrderedCompositeS
         executionStrategy.process( this, inputOptional, walkedPath, output, context );
 
         // We are done, so remove ourselves from the walkedPath
-        walkedPath.removeLast();
+        walkedPath.removeLastElement();
 
         // we matched so increment the matchCount of our parent
         walkedPath.lastElement().getMatchedElement().incrementHashCount();

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrLeafSpec.java
@@ -139,7 +139,7 @@ public class ShiftrLeafSpec extends ShiftrSpec {
             outputPath.write( data, output, walkedPath );
         }
 
-        walkedPath.removeLast();
+        walkedPath.removeLastElement();
 
         if ( realChild ) {
             // we were a "real" child, so increment the matchCount of our parent

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <url>https://github.com/bazaarvoice/jolt</url>
         <connection>scm:git:git@github.com:bazaarvoice/jolt.git</connection>
         <developerConnection>scm:git:git@github.com:bazaarvoice/jolt.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>parent</module>


### PR DESCRIPTION
1. Enable github action for CI.
2. Enable CodeQL for security scanning.
3. Fix one compatibility issue for JDK 21+, introduced by `com.bazaarvoice.jolt.common.tree.WalkedPath`.