### PR TITLE
chore: introduce experimental annotation

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/annotation/Experimental.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/annotation/Experimental.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE})
+public @interface Experimental {
+    String value() default "";
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Function.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Function.java
@@ -16,6 +16,7 @@
 
 package com.bazaarvoice.jolt.modifier.function;
 
+import com.bazaarvoice.jolt.annotation.Experimental;
 import com.bazaarvoice.jolt.common.Optional;
 
 import java.lang.reflect.ParameterizedType;
@@ -93,7 +94,7 @@ import java.util.List;
  * other transforms as well. In short this interface is not yet ready to be implemented outside jolt!
  */
 
-@Deprecated
+@Experimental
 public interface Function {
 
     /**


### PR DESCRIPTION
- `Function` interface was annotated with `@Deprecated` which is not correct
- Instead add an `@Experimental` annotation