### PR TITLE
ci: enable code coverage and integrate it with Codecov #6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: CI
 
 on:
   push:
@@ -33,5 +33,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: 'maven'
       - name: Run tests with Maven
         run: mvn -B test --file pom.xml
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.java == '17' }}
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 JOLT (Community Edition)
 ========
 [![CI](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml/badge.svg)](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/emmansun/jolt-community/graph/badge.svg?token=huhxcPfvTz)](https://codecov.io/gh/emmansun/jolt-community)
 
 JSON to JSON transformation library written in Java where the "specification" for the transform is itself a JSON document.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 JOLT (Community Edition)
 ========
+[![CI](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml/badge.svg)](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/emmansun/jolt-community/graph/badge.svg?token=huhxcPfvTz)](https://codecov.io/gh/emmansun/jolt-community)
 
 JSON to JSON transformation library written in Java where the "specification" for the transform is itself a JSON document.
-
-[![CI](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml/badge.svg)](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml)
 
 ### Community Edition
 This repository is a community-maintained fork of JOLT. For the original version, please visit the [bazaarvoice/jolt](https://github.com/bazaarvoice/jolt) repository.

--- a/jolt-core/pom.xml
+++ b/jolt-core/pom.xml
@@ -51,4 +51,38 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -Dfile.encoding=UTF-8 -Djava.awt.headless=true</argLine>
+                    <excludes>
+                        <exclude>test/integration/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/json-utils/pom.xml
+++ b/json-utils/pom.xml
@@ -41,4 +41,38 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -Dfile.encoding=UTF-8 -Djava.awt.headless=true</argLine>
+                    <excludes>
+                        <exclude>test/integration/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,6 +42,7 @@
         <maven-rat-plugin.version>0.16.1</maven-rat-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
 
         <!-- core -->
         <commons-lang3.version>3.17.0</commons-lang3.version>
@@ -233,6 +234,20 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>            
         </plugins>
 
         <pluginManagement>


### PR DESCRIPTION
Collected test code coverage for below modules now:

1. jolt-core
2. jolt-util

Need @bobeal help to copy the Codecov badge to README.