### PR TITLE
fix(build): 'build.plugins.plugin.version' for org.jacoco:jacoco-mave…

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -238,6 +238,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>report</id>


### PR DESCRIPTION
'build.plugins.plugin.version' for org.jacoco:jacoco-maven-plugin is missing.