### PR TITLE
chore(shiftr): update javadoc and unit test

### DIFF
--- a/jolt-core/src/main/java/io/joltcommunity/jolt/Shiftr.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/Shiftr.java
@@ -205,7 +205,7 @@ import java.util.Map;
  *    </pre>
  * <p>
  * '&' Subkey lookup
- * '&' subkey lookup allows us to referece the values captured by the '*' wildcard.
+ * '&' subkey lookup allows us to reference the values captured by the '*' wildcard.
  * Example, "tag-*-*" would match "tag-Foo-Bar", making
  * &(0,0) = "tag-Foo-Bar"
  * &(0,1) = "Foo"
@@ -259,9 +259,9 @@ import java.util.Map;
  * <p>
  * '#' Wildcard
  * Valid both on the LHS and RHS, but has different behavior / format on either side.
- * The way to think of it, is that it allows you to specify a "synthentic" value, aka a value not found in the input data.
+ * The way to think of it, is that it allows you to specify a "synthetic" value, aka a value not found in the input data.
  * <p>
- * On the RHS of the spec, # is only valid in the the context of an array, like "[#2]".
+ * On the RHS of the spec, # is only valid in the context of an array, like "[#2]".
  * What "[#2]" means is, go up the three levels and ask that node how many matches it has had, and then use that as an index
  * in the arrays.
  * This means that, while Shiftr is doing its parallel tree walk of the input data and the spec, it tracks how many matches it
@@ -286,13 +286,13 @@ import java.util.Map;
  * <p>
  * '|' Wildcard
  * Valid only on the LHS of the spec.
- * This 'or' wildcard allows you to match multiple input keys.   Useful if you don't always know exactly what your input data will be.
+ * This 'or' wildcard allows you to match multiple input keys. Useful if you don't always know exactly what your input data will be.
  * Example Spec :
  * <pre>
  *   {
  *     "rating|Rating" : "rating-primary"   // match "rating" or "Rating" copy the data to "rating-primary"
  *   }
- *   </pre>
+ * </pre>
  * This is really just syntactic sugar, as the implementation really just treats the key "rating|Rating" as two keys when processing.
  * <p>
  * <p>
@@ -321,7 +321,7 @@ import java.util.Map;
  * Thus the '@' wildcard is the mean "copy the value of the data at this level in the tree, to the output".
  * <p>
  * Advanced '@' sign wildcard.
- * The format is lools like "@(3,title)", where
+ * The format is looks like "@(3,title)", where
  * "3" means go up the tree 3 levels and then lookup the key
  * "title" and use the value at that key.
  * <p>
@@ -439,18 +439,18 @@ import java.util.Map;
  * Algorithm High Level
  * Walk the input data, and Shiftr spec simultaneously, and execute the Shiftr command/mapping each time
  * there is a match.
- * <p>
+ * <pre>
  * Algorithm Low Level
  * - Simultaneously walk of the spec and input JSon, and maintain a walked "input" path data structure.
  * - Determine a match between input JSON key and LHS spec, by matching LHS spec keys in the following order :
  * -- Note that '|' keys are are split into their subkeys, eg "literal", '*', or '&' LHS keys
- * <p>
  * 1) Try to match the input key with "literal" spec key values
  * 2) If no literal match is found, try to match against LHS '&' computed values.
  * 2.1) For deterministic behavior, if there is more than one '&' LHS key, they are applied/matched in alphabetical order,
  * after the '&' syntactic sugar is replaced with its canonical form.
  * 3) If no match is found, try to match against LHS keys with '*' wildcard values.
  * 3.1) For deterministic behavior, '*' wildcard keys are sorted and applied/matched in alphabetical order.
+ * </pre>
  * <p>
  * Note, processing of the '@' and '$' LHS keys always occur if their parent's match, and do not block any other matching.
  * <p>

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/shiftr/spec/ShiftrSpec.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/shiftr/spec/ShiftrSpec.java
@@ -31,15 +31,17 @@ import io.joltcommunity.jolt.common.spec.BaseSpec;
  * CompositeSpec : where the RHS is a map of children Specs
  * <p>
  * Mapping of JSON Shiftr Spec to Spec objects :
+ * <pre>
  * {
- * rating-*" : {      // CompositeSpec with one child and a Star PathElement
- * "&(1)" : {       // CompositeSpec with one child and a Reference PathElement
- * "foo: {        // CompositeSpec with one child and a Literal PathElement
- * "value" : "Rating-&1.value"  // OutputtingSpec with a Literal PathElement and one write path
+ *   rating-*" : {      // CompositeSpec with one child and a Star PathElement
+ *     "&(1)" : {       // CompositeSpec with one child and a Reference PathElement
+ *       "foo: {        // CompositeSpec with one child and a Literal PathElement
+ *         "value" : "Rating-&1.value"  // OutputtingSpec with a Literal PathElement and one write path
+ *       }
+ *     }
+ *   }
  * }
- * }
- * }
- * }
+ * </pre>
  * <p>
  * The tree structure of formed by the CompositeSpecs is what is used during Shiftr transforms
  * to do the parallel tree walk with the input data tree.

--- a/jolt-core/src/test/java/io/joltcommunity/jolt/shiftr/ShiftrTraversrTest.java
+++ b/jolt-core/src/test/java/io/joltcommunity/jolt/shiftr/ShiftrTraversrTest.java
@@ -34,7 +34,7 @@ public class ShiftrTraversrTest {
         return new Object[][]{
                 {
                         "simple place",
-                        Arrays.asList("tuna"),
+                        List.of("tuna"),
                         "tuna",
                         "a.b",
                         Arrays.asList("a", "b"),
@@ -42,7 +42,7 @@ public class ShiftrTraversrTest {
                 },
                 {
                         "simple explicit array place",
-                        Arrays.asList("tuna"),
+                        List.of("tuna"),
                         null,
                         "a.b[]",
                         Arrays.asList("a", "b", "[]"),
@@ -50,7 +50,7 @@ public class ShiftrTraversrTest {
                 },
                 {
                         "simple explicit array place with sub",
-                        Arrays.asList("tuna"),
+                        List.of("tuna"),
                         null,
                         "a.b[].c",
                         Arrays.asList("a", "b", "[]", "c"),
@@ -58,7 +58,7 @@ public class ShiftrTraversrTest {
                 },
                 {
                         "simple array place",
-                        Arrays.asList("tuna"),
+                        List.of("tuna"),
                         "tuna",
                         "a.b.[1]",
                         Arrays.asList("a", "b", "1"),
@@ -66,7 +66,7 @@ public class ShiftrTraversrTest {
                 },
                 {
                         "nested array place",
-                        Arrays.asList("tuna"),
+                        List.of("tuna"),
                         "tuna",
                         "a.b[1].c",
                         Arrays.asList("a", "b", "1", "c"),

--- a/jolt-core/src/test/java/io/joltcommunity/jolt/shiftr/ShiftrUnitTest.java
+++ b/jolt-core/src/test/java/io/joltcommunity/jolt/shiftr/ShiftrUnitTest.java
@@ -39,15 +39,49 @@ public class ShiftrUnitTest {
         return new Object[][]{
                 {
                         "Simple * and Reference",
-                        JsonUtils.jsonToMap("{ \"tuna-*-marlin-*\" : { \"rating-*\" : \"&(1,2).&.value\" } }"),
-                        JsonUtils.jsonToMap("{ \"tuna-A-marlin-AAA\" : { \"rating-BBB\" : \"bar\" } }"),
-                        JsonUtils.jsonToMap("{ \"AAA\" : { \"rating-BBB\" : { \"value\" : \"bar\" } } }")
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna-*-marlin-*" : {
+                                     "rating-*" : "&(1,2).&.value"
+                                  }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna-A-marlin-AAA" : {
+                                     "rating-BBB" : "bar"
+                                  }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "AAA" : {
+                                     "rating-BBB" : {
+                                        "value" : "bar"
+                                     }
+                                   }
+                                }""")
                 },
                 {
                         "Shift to two places",
-                        JsonUtils.jsonToMap("{ \"tuna-*-marlin-*\" : { \"rating-*\" : [ \"&(1,2).&.value\", \"foo\"] } }"),
-                        JsonUtils.jsonToMap("{ \"tuna-A-marlin-AAA\" : { \"rating-BBB\" : \"bar\" } }"),
-                        JsonUtils.jsonToMap("{ \"foo\" : \"bar\", \"AAA\" : { \"rating-BBB\" : { \"value\" : \"bar\" } } }")
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna-*-marlin-*" : {
+                                    "rating-*" : [ "&(1,2).&.value", "foo"]
+                                   }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna-A-marlin-AAA" : {
+                                    "rating-BBB" : "bar"
+                                   }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "foo" : "bar", "AAA" : {
+                                    "rating-BBB" : {
+                                      "value" : "bar"
+                                    }
+                                  }
+                                }""")
                 },
                 {
                         "Or",
@@ -57,21 +91,62 @@ public class ShiftrUnitTest {
                 },
                 {
                         "KeyRef",
-                        JsonUtils.jsonToMap("{ \"rating-*\" : { \"&(0,1)\" : { \"match\" : \"&\" } } }"),
-                        JsonUtils.jsonToMap("{ \"rating-a\" : { \"a\" : { \"match\": \"a-match\" }, \"random\" : { \"match\" : \"noise\" } }," +
-                                "              \"rating-c\" : { \"c\" : { \"match\": \"c-match\" }, \"random\" : { \"match\" : \"noise\" } } }"),
-                        JsonUtils.jsonToMap("{ \"match\" : [ \"a-match\", \"c-match\" ] }")
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "rating-*" : {
+                                    "&(0,1)" : {
+                                      "match" : "&"
+                                    }
+                                  }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                  {
+                                    "rating-a" : {
+                                      "a" : {
+                                        "match": "a-match"
+                                      },
+                                      "random" : {
+                                        "match" : "noise"
+                                      }
+                                    },
+                                    "rating-c" : {
+                                      "c" : {
+                                        "match": "c-match"
+                                      },
+                                    "random" : {
+                                      "match" : "noise"
+                                    }
+                                  }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "match" : [
+                                    "a-match",
+                                    "c-match"
+                                  ]
+                                }""")
                 },
                 {
                         "Complex array write",
-                        JsonUtils.jsonToMap("{ \"tuna-*-marlin-*\" : { \"rating-*\" : \"tuna[&(1,1)].marlin[&(1,2)].&(0,1)\" } }"),
-                        JsonUtils.jsonToMap("{ \"tuna-2-marlin-3\" : { \"rating-BBB\" : \"bar\" }," +
-                                "\"tuna-1-marlin-0\" : { \"rating-AAA\" : \"mahi\" } }"),
-                        JsonUtils.jsonToMap("{ \"tuna\" : [ null, " +
-                                "                           { \"marlin\" : [ { \"AAA\" : \"mahi\" } ] }, " +
-                                "                           { \"marlin\" : [ null, null, null, { \"BBB\" : \"bar\" } ] } " +
-                                "                         ] " +
-                                "            }")
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna-*-marlin-*" : {
+                                    "rating-*" : "tuna[&(1,1)].marlin[&(1,2)].&(0,1)"
+                                  }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna-2-marlin-3" : { "rating-BBB" : "bar" },
+                                  "tuna-1-marlin-0" : { "rating-AAA" : "mahi" }
+                                }"""),
+                        JsonUtils.jsonToMap("""
+                                {
+                                  "tuna": [
+                                    null,
+                                    { "marlin" : [ { "AAA" : "mahi" } ] },
+                                    { "marlin" : [ null, null, null, { "BBB" : "bar" } ] }
+                                  ]
+                                }""")
                 }
         };
     }

--- a/jolt-core/src/test/java/io/joltcommunity/jolt/shiftr/ShiftrWritrTest.java
+++ b/jolt-core/src/test/java/io/joltcommunity/jolt/shiftr/ShiftrWritrTest.java
@@ -34,22 +34,22 @@ public class ShiftrWritrTest {
 
         ShiftrWriter path = new ShiftrWriter("SecondaryRatings.tuna-&(0,1)-marlin.Value");
 
-        Assert.assertEquals("SecondaryRatings", path.get(0).getRawKey());
-        Assert.assertEquals("SecondaryRatings", path.get(0).toString());
-        Assert.assertEquals("Value", path.get(2).getRawKey());
-        Assert.assertEquals("Value", path.get(2).toString());
-        Assert.assertEquals("Value", path.get(2).toString());
+        Assert.assertEquals(path.get(0).getRawKey(), "SecondaryRatings");
+        Assert.assertEquals(path.get(0).toString(), "SecondaryRatings");
+        Assert.assertEquals(path.get(2).getRawKey(), "Value");
+        Assert.assertEquals(path.get(2).toString(), "Value");
+        Assert.assertEquals(path.get(2).toString(), "Value");
 
         AmpPathElement refElement = (AmpPathElement) path.get(1);
 
-        Assert.assertEquals(3, refElement.getTokens().size());
-        Assert.assertEquals("tuna-", (String) refElement.getTokens().get(0));
-        Assert.assertEquals("-marlin", (String) refElement.getTokens().get(2));
+        Assert.assertEquals(refElement.getTokens().size(), 3);
+        Assert.assertEquals((String) refElement.getTokens().get(0), "tuna-");
+        Assert.assertEquals((String) refElement.getTokens().get(2), "-marlin");
 
         Assert.assertTrue(refElement.getTokens().get(1) instanceof AmpReference);
         AmpReference ref = (AmpReference) refElement.getTokens().get(1);
-        Assert.assertEquals(0, ref.getPathIndex());
-        Assert.assertEquals(1, ref.getKeyGroup());
+        Assert.assertEquals(ref.getPathIndex(), 0);
+        Assert.assertEquals(ref.getKeyGroup(), 1);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class ShiftrWritrTest {
 
         ShiftrWriter path = new ShiftrWriter("ugc.photos-&1-bob[&2]");
 
-        Assert.assertEquals(3, path.size());
+        Assert.assertEquals(path.size(), 3);
         {  // 0
             PathElement pe = path.get(0);
             Assert.assertTrue(pe instanceof LiteralPathElement, "First pathElement should be a literal one.");
@@ -69,22 +69,22 @@ public class ShiftrWritrTest {
 
             AmpPathElement refElement = (AmpPathElement) pe;
 
-            Assert.assertEquals(3, refElement.getTokens().size());
+            Assert.assertEquals(refElement.getTokens().size(), 3);
 
             {
                 Assert.assertTrue(refElement.getTokens().get(0) instanceof String);
-                Assert.assertEquals("photos-", (String) refElement.getTokens().get(0));
+                Assert.assertEquals((String) refElement.getTokens().get(0), "photos-");
             }
             {
                 Assert.assertTrue(refElement.getTokens().get(1) instanceof AmpReference);
                 AmpReference ref = (AmpReference) refElement.getTokens().get(1);
-                Assert.assertEquals("&(1,0)", ref.getCanonicalForm());
-                Assert.assertEquals(1, ref.getPathIndex());
-                Assert.assertEquals(0, ref.getKeyGroup());
+                Assert.assertEquals(ref.getCanonicalForm(), "&(1,0)");
+                Assert.assertEquals(ref.getPathIndex(), 1);
+                Assert.assertEquals(ref.getKeyGroup(), 0);
             }
             {
                 Assert.assertTrue(refElement.getTokens().get(2) instanceof String);
-                Assert.assertEquals("-bob", (String) refElement.getTokens().get(2));
+                Assert.assertEquals((String) refElement.getTokens().get(2), "-bob");
             }
         }
 
@@ -93,7 +93,7 @@ public class ShiftrWritrTest {
             Assert.assertTrue(pe instanceof ArrayPathElement, "Third pathElement should be a literal one.");
 
             ArrayPathElement arrayElement = (ArrayPathElement) pe;
-            Assert.assertEquals("[&(2,0)]", arrayElement.getCanonicalForm());
+            Assert.assertEquals(arrayElement.getCanonicalForm(), "[&(2,0)]");
         }
     }
 
@@ -107,17 +107,17 @@ public class ShiftrWritrTest {
         Assert.assertNull(lpe);
 
         lpe = pe1.match("tuna-A-marlin-AAA", new WalkedPath());
-        Assert.assertEquals("tuna-A-marlin-AAA", lpe.getRawKey());
-        Assert.assertEquals("tuna-A-marlin-AAA", lpe.getSubKeyRef(0));
-        Assert.assertEquals(3, lpe.getSubKeyCount());
-        Assert.assertEquals("A", lpe.getSubKeyRef(1));
-        Assert.assertEquals("AAA", lpe.getSubKeyRef(2));
+        Assert.assertEquals(lpe.getRawKey(), "tuna-A-marlin-AAA");
+        Assert.assertEquals(lpe.getSubKeyRef(0), "tuna-A-marlin-AAA");
+        Assert.assertEquals(lpe.getSubKeyCount(), 3);
+        Assert.assertEquals(lpe.getSubKeyRef(1), "A");
+        Assert.assertEquals(lpe.getSubKeyRef(2), "AAA");
 
         MatchedElement lpe2 = pe2.match("rating-BBB", new WalkedPath(null, lpe));
-        Assert.assertEquals("rating-BBB", lpe2.getRawKey());
-        Assert.assertEquals("rating-BBB", lpe2.getSubKeyRef(0));
-        Assert.assertEquals(2, lpe2.getSubKeyCount());
-        Assert.assertEquals("BBB", lpe2.getSubKeyRef(1));
+        Assert.assertEquals(lpe2.getRawKey(), "rating-BBB");
+        Assert.assertEquals(lpe2.getSubKeyRef(0), "rating-BBB");
+        Assert.assertEquals(lpe2.getSubKeyCount(), 2);
+        Assert.assertEquals(lpe2.getSubKeyRef(1), "BBB");
 
         ShiftrWriter outputPath = new ShiftrWriter("&(1,2).&.value");
         WalkedPath twoSteps = new WalkedPath(null, lpe);
@@ -125,17 +125,17 @@ public class ShiftrWritrTest {
         {
             EvaluatablePathElement outputElement = (EvaluatablePathElement) outputPath.get(0);
             String evaledLeafOutput = outputElement.evaluate(twoSteps);
-            Assert.assertEquals("AAA", evaledLeafOutput);
+            Assert.assertEquals(evaledLeafOutput, "AAA");
         }
         {
             EvaluatablePathElement outputElement = (EvaluatablePathElement) outputPath.get(1);
             String evaledLeafOutput = outputElement.evaluate(twoSteps);
-            Assert.assertEquals("rating-BBB", evaledLeafOutput);
+            Assert.assertEquals(evaledLeafOutput, "rating-BBB");
         }
         {
             EvaluatablePathElement outputElement = (EvaluatablePathElement) outputPath.get(2);
             String evaledLeafOutput = outputElement.evaluate(twoSteps);
-            Assert.assertEquals("value", evaledLeafOutput);
+            Assert.assertEquals(evaledLeafOutput, "value");
         }
     }
 
@@ -148,28 +148,28 @@ public class ShiftrWritrTest {
 
         // match them against some data to get LiteralPathElements with captured values
         MatchedElement lpe = pe1.match("tuna-2-marlin-3", new WalkedPath());
-        Assert.assertEquals("2", lpe.getSubKeyRef(1));
-        Assert.assertEquals("3", lpe.getSubKeyRef(2));
+        Assert.assertEquals(lpe.getSubKeyRef(1), "2");
+        Assert.assertEquals(lpe.getSubKeyRef(2), "3");
 
         MatchedElement lpe2 = pe2.match("rating-BBB", new WalkedPath(null, lpe));
-        Assert.assertEquals(2, lpe2.getSubKeyCount());
-        Assert.assertEquals("BBB", lpe2.getSubKeyRef(1));
+        Assert.assertEquals(lpe2.getSubKeyCount(), 2);
+        Assert.assertEquals(lpe2.getSubKeyRef(1), "BBB");
 
         // Build an write path path
         ShiftrWriter shiftrWriter = new ShiftrWriter("tuna[&(1,1)].marlin[&(1,2)].&(0,1)");
 
-        Assert.assertEquals(5, shiftrWriter.size());
-        Assert.assertEquals("tuna.[&(1,1)].marlin.[&(1,2)].&(0,1)", shiftrWriter.getCanonicalForm());
+        Assert.assertEquals(shiftrWriter.size(), 5);
+        Assert.assertEquals(shiftrWriter.getCanonicalForm(), "tuna.[&(1,1)].marlin.[&(1,2)].&(0,1)");
 
         // Evaluate the write path against the LiteralPath elements we build above ( like Shiftr does )
         WalkedPath twoSteps = new WalkedPath(null, lpe);
         twoSteps.add(null, lpe2);
         List<String> stringPath = shiftrWriter.evaluate(twoSteps);
 
-        Assert.assertEquals("tuna", stringPath.get(0));
-        Assert.assertEquals("2", stringPath.get(1));
-        Assert.assertEquals("marlin", stringPath.get(2));
-        Assert.assertEquals("3", stringPath.get(3));
-        Assert.assertEquals("BBB", stringPath.get(4));
+        Assert.assertEquals(stringPath.get(0), "tuna");
+        Assert.assertEquals(stringPath.get(1), "2");
+        Assert.assertEquals(stringPath.get(2), "marlin");
+        Assert.assertEquals(stringPath.get(3), "3");
+        Assert.assertEquals(stringPath.get(4), "BBB");
     }
 }

--- a/jolt-core/src/test/java/io/joltcommunity/jolt/traversr/SimpleTraversalTest.java
+++ b/jolt-core/src/test/java/io/joltcommunity/jolt/traversr/SimpleTraversalTest.java
@@ -72,7 +72,7 @@ public class SimpleTraversalTest {
 
         Optional actual = simpleTraversal.get(tree);
 
-        Assert.assertEquals(expected, actual.get());
+        Assert.assertEquals(actual.get(), expected);
         JoltTestUtil.runDiffy("Get should not have modified the input", original, tree);
     }
 
@@ -83,7 +83,7 @@ public class SimpleTraversalTest {
 
         Assert.assertEquals(toSet, simpleTraversal.set(actual, toSet).get()); // set should be successful
 
-        Assert.assertEquals(expected, actual);
+        Assert.assertEquals(actual, expected);
     }
 
     @Test
@@ -95,11 +95,11 @@ public class SimpleTraversalTest {
         Object actual = new HashMap<>();
 
         Assert.assertFalse(traversal.get(actual).isPresent());
-        Assert.assertEquals(0, ((HashMap<?, ?>) actual).size()); // get didn't add anything
+        Assert.assertEquals(((HashMap<?, ?>) actual).size(), 0); // get didn't add anything
 
         // Add two things and validate the Auto Expand array
-        Assert.assertEquals("one", traversal.set(actual, "one").get());
-        Assert.assertEquals("two", traversal.set(actual, "two").get());
+        Assert.assertEquals(traversal.set(actual, "one").get(), "one");
+        Assert.assertEquals(traversal.set(actual, "two").get(), "two");
 
         JoltTestUtil.runDiffy(expected, actual);
     }
@@ -112,13 +112,13 @@ public class SimpleTraversalTest {
         Object expectedOne = JsonUtils.jsonToMap("{ \"a\" : { \"b\" : \"one\" } }");
         Object expectedTwo = JsonUtils.jsonToMap("{ \"a\" : { \"b\" : \"two\" } }");
 
-        Assert.assertEquals("tuna", traversal.get(actual).get());
+        Assert.assertEquals(traversal.get(actual).get(), "tuna");
 
         // Set twice and verify that the sets did in fact overwrite
-        Assert.assertEquals("one", traversal.set(actual, "one").get());
+        Assert.assertEquals(traversal.set(actual, "one").get(), "one");
         JoltTestUtil.runDiffy(expectedOne, actual);
 
-        Assert.assertEquals("two", traversal.set(actual, "two").get());
+        Assert.assertEquals(traversal.set(actual, "two").get(), "two");
         JoltTestUtil.runDiffy(expectedTwo, actual);
     }
 


### PR DESCRIPTION
1. Flip compared arguments.
2. Fix and update javadoc.
3. Use text block to improve the test json data’s readability.