### PR TITLE
chore(defaultr): change access modifiers of Key's methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 JOLT (Community Edition)
 ========
 [![CI](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml/badge.svg)](https://github.com/jolt-community/jolt-community/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jolt-community/jolt-community/graph/badge.svg?token=ZH2ZCH1J8Y)](https://codecov.io/gh/jolt-community/jolt-community)
 
 JSON to JSON transformation library written in Java where the "specification" for the transform is itself a JSON document.
 

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/Defaultr.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/Defaultr.java
@@ -150,7 +150,7 @@ import java.util.Map;
  * added if they are not already present in the input document (either naturally or having been defaulted
  * in from literal spec keys).
  * <p>
- * <p>
+ * <pre>
  * Algorithm :
  * 1) Walk the spec
  * 2) for each literal key in the spec (specKey)
@@ -161,6 +161,7 @@ import java.util.Map;
  * 3) for each wildcard in the spec
  * 3.1) find all keys from the defaultee that match the wildcard
  * 3.2) treat each key as a literal speckey
+ * </pre>
  * <p>
  * Corner Cases :
  * <p>
@@ -238,9 +239,13 @@ public class Defaultr implements SpecDriven, Transform {
         return input;
     }
 
-    public interface WildCards {
-        String STAR = "*";
-        String OR = "|";
-        String ARRAY = "[]";
+    public static final class WildCards {
+        public static final String STAR = "*";
+        public static final String OR = "|";
+        public static final String ARRAY = "[]";
+
+        private WildCards() {
+            // Prevent instantiation
+        }
     }
 }

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/defaultr/ArrayKey.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/defaultr/ArrayKey.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class ArrayKey extends Key {
 
-    private Collection<Integer> keyInts;
+    private final Collection<Integer> keyInts;
     private int keyInt = -1;
 
     public ArrayKey(String jsonKey, Object spec) {
@@ -39,7 +39,7 @@ public class ArrayKey extends Key {
                 break;
             case LITERAL:
                 keyInt = Integer.parseInt(rawKey);
-                keyInts = Arrays.asList(keyInt);
+                keyInts = List.of(keyInt);
                 break;
             case STAR:
                 keyInts = Collections.emptyList();

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/defaultr/Key.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/defaultr/Key.java
@@ -39,8 +39,7 @@ public abstract class Key {
     private int orCount = 0;
     private int outputArraySize = -1;
 
-    public Key(String rawJsonKey, Object spec) {
-
+    protected Key(String rawJsonKey, Object spec) {
         rawKey = rawJsonKey;
         if (rawJsonKey.endsWith(Defaultr.WildCards.ARRAY)) {
             isArrayOutput = true;
@@ -55,7 +54,7 @@ public abstract class Key {
                 orCount = keyStrings.size();
                 break;
             case LITERAL:
-                keyStrings = Arrays.asList(rawKey);
+                keyStrings = List.of(rawKey);
                 break;
             case STAR:
                 keyStrings = Collections.emptyList();
@@ -141,8 +140,7 @@ public abstract class Key {
         }
 
         // Find and sort the children DefaultrKeys by precedence: literals, |, then *
-        ArrayList<Key> sortedChildren = new ArrayList<>();
-        sortedChildren.addAll(children);
+        List<Key> sortedChildren = new ArrayList<>(children);
         sortedChildren.sort(keyComparator);
 
         for (Key childKey : sortedChildren) {
@@ -159,23 +157,23 @@ public abstract class Key {
      */
     protected abstract void applyChild(Object container);
 
-    public int getOrCount() {
+    private int getOrCount() {
         return orCount;
     }
 
-    public boolean isArrayOutput() {
+    private boolean isArrayOutput() {
         return isArrayOutput;
     }
 
-    public OPS getOp() {
-        return op;
-    }
-
-    public int getOutputArraySize() {
+    private int getOutputArraySize() {
         return outputArraySize;
     }
 
-    public Object createOutputContainerObject() {
+    protected OPS getOp() {
+        return op;
+    }
+
+    protected Object createOutputContainerObject() {
         if (isArrayOutput()) {
             return new ArrayList<>();
         } else {
@@ -202,5 +200,4 @@ public abstract class Key {
             return opsEqual;
         }
     }
-
 }

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/defaultr/OPS.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/defaultr/OPS.java
@@ -20,10 +20,19 @@ import io.joltcommunity.jolt.Defaultr;
 import io.joltcommunity.jolt.exception.SpecException;
 
 import java.util.Comparator;
+import java.util.EnumMap;
 
 public enum OPS {
 
     STAR, OR, LITERAL;
+
+    private static final EnumMap<OPS, Integer> precedenceMap = new EnumMap<>(OPS.class);
+
+    static {
+        precedenceMap.put(LITERAL, 1);
+        precedenceMap.put(OR, 2);
+        precedenceMap.put(STAR, 3);
+    }
 
     public static OPS parse(String key) {
         if (key.contains(Defaultr.WildCards.STAR)) {
@@ -41,39 +50,9 @@ public enum OPS {
     }
 
     public static class OpsPrecedenceComparator implements Comparator<OPS> {
-        /**
-         * The order we want to apply Defaultr logic is Literals, Or, and then Star.
-         * Since we walk the sorted data from 0 to n, that means Literals need to low, and Star should be high.
-         */
         @Override
-        public int compare(OPS ops, OPS ops1) {
-
-            // a negative integer, zero, or a positive integer as the first argument is less than, equal to, or greater than the second.
-            // s < s1 -> -1
-            // s = s1 -> 0
-            // s > s1 -> 1
-
-            if (ops == ops1) {
-                return 0;
-            }
-
-            if (STAR == ops) {
-                return 1;
-            }
-            if (LITERAL == ops) {
-                return -1;
-            }
-
-            // if we get here, "ops" has to equal OR
-            if (STAR == ops1) {
-                return -1;
-            }
-            if (LITERAL == ops1) {
-                return 1;
-            }
-
-            // both are ORs, should never get here
-            throw new IllegalStateException("Someone has added an op type without changing this method.");
+        public int compare(OPS ops1, OPS ops2) {
+            return Integer.compare(precedenceMap.get(ops1), precedenceMap.get(ops2));
         }
     }
 }

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/removr/Removr.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/removr/Removr.java
@@ -116,8 +116,8 @@ import java.util.Map;
  *    }
  *    </pre>
  * In this example, "Set1" and "Set2" under rating both have the same structure, and thus we can use the '*'
- * to allow use to write more compact rules to remove "b" from all children under ratings. This is especially useful when we don't know
- * how many children will  be under ratings, but we would like to nuke certain part of it across.
+ * to allow us to write more compact rules to remove "b" from all children under ratings. This is especially useful when we don't know
+ * how many children will be under ratings, but we would like to remove certain parts of it altogether.
  * <p>
  * '*' wildcard as part of a key :
  * This is useful for working with input JSON with keys that are "prefixed".
@@ -166,7 +166,7 @@ import java.util.Map;
  * <p>
  * It can walk thru all the elements of an array with the "*" wildcard.
  * <p>
- * Additionally, it can remove individual array indicies.  To do this the LHS key
+ * Additionally, it can remove individual array indices. To do this the LHS key
  * must be a number but in String format.
  * <p>
  * Example

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/removr/spec/RemovrCompositeSpec.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/removr/spec/RemovrCompositeSpec.java
@@ -23,28 +23,28 @@ import io.joltcommunity.jolt.exception.SpecException;
 
 import java.util.*;
 
-/*
-    Sample Spec
-    "spec": {
-        "ineedtoberemoved":"" //literal leaf element
-        "TAG-*$*": "",       //Leaf Computed element
-        "TAG-*#*": "",
-
-        "*pants*" : "",
-
-         "buckets": {     //composite literal Path element
-            "a$*": ""    //Computed Leaf element
-         },
-         "rating*":{    //composite computed path element
-            "*":{       //composite computed path element
-                "a":""  //literal leaf element
-            }
-        }
-    }
-*/
-
 /**
  * Removr Spec that has children. In a removr spec, whenever the RHS is a Map, we build a RemovrCompositeSpec
+ * <pre>
+ * Sample Spec:
+ *
+ *     "spec": {
+ *         "ineedtoberemoved":"" //literal leaf element
+ *         "TAG-*$*": "",       //Leaf Computed element
+ *         "TAG-*#*": "",
+ *
+ *         "*pants*" : "",
+ *
+ *          "buckets": {     //composite literal Path element
+ *             "a$*": ""    //Computed Leaf element
+ *          },
+ *          "rating*":{    //composite computed path element
+ *             "*":{       //composite computed path element
+ *                 "a":""  //literal leaf element
+ *             }
+ *         }
+ *     }
+ *  </pre>
  */
 public class RemovrCompositeSpec extends RemovrSpec {
 
@@ -61,7 +61,7 @@ public class RemovrCompositeSpec extends RemovrSpec {
                 RemovrSpec childSpec;
                 if (rawRhs instanceof Map) {
                     childSpec = new RemovrCompositeSpec(keyString, (Map<String, Object>) rawRhs);
-                } else if (rawRhs instanceof String && ((String) rawRhs).trim().length() == 0) {
+                } else if (rawRhs instanceof String && ((String) rawRhs).trim().isEmpty()) {
                     childSpec = new RemovrLeafSpec(keyString);
                 } else {
                     throw new SpecException("Invalid Removr spec RHS. Should be an empty string or Map");
@@ -127,21 +127,21 @@ public class RemovrCompositeSpec extends RemovrSpec {
             if (subInput instanceof List) {
 
                 List<Object> subList = (List<Object>) subInput;
-                Set<Integer> indiciesToRemove = new HashSet<>();
+                Set<Integer> indicesToRemove = new HashSet<>();
 
-                // build a list of all indicies to remove
+                // build a list of all indices to remove
                 for (RemovrSpec childSpec : children) {
-                    indiciesToRemove.addAll(childSpec.applyToList(subList));
+                    indicesToRemove.addAll(childSpec.applyToList(subList));
                 }
 
-                List<Integer> uniqueIndiciesToRemove = new ArrayList<>(indiciesToRemove);
+                List<Integer> uniqueIndicesToRemove = new ArrayList<>(indicesToRemove);
                 // Sort the list from Biggest to Smallest, so that when we remove items from the input
                 //  list we don't muck up the order.
                 // Aka removing 0 _then_ 3 would be bad, because we would have actually removed
                 //  0 and 4 from the "original" list.
-                uniqueIndiciesToRemove.sort(Comparator.reverseOrder());
+                uniqueIndicesToRemove.sort(Comparator.reverseOrder());
 
-                for (int index : uniqueIndiciesToRemove) {
+                for (int index : uniqueIndicesToRemove) {
                     subList.remove(index);
                 }
             } else if (subInput instanceof Map) {
@@ -154,7 +154,7 @@ public class RemovrCompositeSpec extends RemovrSpec {
                     keysToRemove.addAll(childSpec.applyToMap(subInputMap));
                 }
 
-                subInputMap.keySet().removeAll(keysToRemove);
+                keysToRemove.forEach(subInputMap.keySet()::remove);
             }
         }
     }

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/removr/spec/RemovrSpec.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/removr/spec/RemovrSpec.java
@@ -27,7 +27,7 @@ public abstract class RemovrSpec {
 
     protected final MatchablePathElement pathElement;
 
-    public RemovrSpec(String rawJsonKey) {
+    protected RemovrSpec(String rawJsonKey) {
         PathElement pathElement = parse(rawJsonKey);
 
         if (!(pathElement instanceof MatchablePathElement)) {

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/removr/spec/RemovrSpec.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/removr/spec/RemovrSpec.java
@@ -28,17 +28,11 @@ public abstract class RemovrSpec {
     protected final MatchablePathElement pathElement;
 
     protected RemovrSpec(String rawJsonKey) {
-        PathElement pathElement = parse(rawJsonKey);
-
-        if (!(pathElement instanceof MatchablePathElement)) {
-            throw new SpecException("Spec LHS key=" + rawJsonKey + " is not a valid LHS key.");
-        }
-
-        this.pathElement = (MatchablePathElement) pathElement;
+        this.pathElement = parse(rawJsonKey);
     }
 
     // Ex Keys :  *, cdv-*, *-$de
-    public static PathElement parse(String key) {
+    public static MatchablePathElement parse(String key) {
         if ("*".equals(key)) {
             return new StarAllPathElement(key);
         }

--- a/jolt-core/src/main/java/io/joltcommunity/jolt/shiftr/spec/ShiftrSpec.java
+++ b/jolt-core/src/main/java/io/joltcommunity/jolt/shiftr/spec/ShiftrSpec.java
@@ -55,7 +55,7 @@ public abstract class ShiftrSpec implements BaseSpec {
     // The processed key from the JSON config
     protected final MatchablePathElement pathElement;
 
-    public ShiftrSpec(String rawJsonKey) {
+    protected ShiftrSpec(String rawJsonKey) {
         this.pathElement = PathElementBuilder.buildMatchablePathElement(rawJsonKey);
     }
 

--- a/jolt-core/src/test/java/io/joltcommunity/jolt/RemovrTest.java
+++ b/jolt-core/src/test/java/io/joltcommunity/jolt/RemovrTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
 public class RemovrTest {
@@ -76,4 +77,34 @@ public class RemovrTest {
         new Removr(spec);
     }
 
+    @DataProvider
+    public Object[][] badSpecs() throws IOException {
+        return new Object[][]{
+                {
+                        "Null Spec",
+                        null,
+                },
+                {
+                        "List Spec",
+                        new ArrayList<>(),
+                },
+                {
+                        "Invalid rhs string",
+                        JsonUtils.javason("{ 'tuna' : 'marlin[-1]' }"),
+                },
+                {
+                        "Invalid rhs type - not a Map (number)",
+                        JsonUtils.javason("{ 'tuna' : 123 }"),
+                },
+                {
+                        "Invalid rhs type - not a Map (array)",
+                        JsonUtils.javason("{ 'tuna' : [] }"),
+                }
+        };
+    }
+
+    @Test(dataProvider = "badSpecs", expectedExceptions = SpecException.class)
+    public void failureUnitTest(String testName, Object spec) {
+        new Removr(spec);
+    }
 }


### PR DESCRIPTION
1. change access modifiers of Key's methods to control visibility;
2. refactor `OPS` to make the Comparator's implementation simple;
3. change `Defaultr.WildCards` from interface to final class.
4. [chore(removr): remove useless type checking](https://github.com/jolt-community/jolt-community/pull/20/commits/1a7c5cebd7451430f55468d63c2f5ec0e16f3718)
5. [chore(removr): fix typo and update javadoc](https://github.com/jolt-community/jolt-community/pull/20/commits/c36762635f36ad8161cbfb258e6125fce2b44fca)
6. add codecov badge to README
