### PR TITLE
ci: update release workflows to support protected branches

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,9 @@ permissions:
 jobs:
   main-to-develop-sync:
     permissions:
-      contents: write  # for git push
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
 
     steps:
@@ -18,14 +20,10 @@ jobs:
         with:
           ref: main
 
-      - name: Configure Git
-        run: |
-          git config user.name "joltbot"
-          git config user.email "joltbot@users.noreply.github.com"
-
-      - name: Merge main into develop
-        run: |
-          git fetch origin develop
-          git checkout develop
-          git merge main --no-ff --allow-unrelated-histories
-          git push origin develop
+      - name: Create PR from main to develop
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Merge main into develop"
+          body: "This PR merges changes from main into develop."
+          base: develop

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,7 +9,9 @@ permissions:
 jobs:
   develop-to-main-sync:
     permissions:
-      contents: write  # for git push
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
 
     steps:
@@ -18,14 +20,10 @@ jobs:
         with:
           ref: develop
 
-      - name: Configure Git
-        run: |
-          git config user.name "joltbot"
-          git config user.email "joltbot@users.noreply.github.com"
-
-      - name: Merge develop into main
-        run: |
-          git fetch origin main
-          git checkout main
-          git merge develop --no-ff --allow-unrelated-histories -X theirs
-          git push origin main
+      - name: Create PR from develop to main
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Merge develop into main"
+          body: "This PR merges changes from develop into main."
+          base: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,43 @@ on:
 
 permissions:
   contents: write # Required for pushing changes and tags
-  packages: write # Required for publishing packages (work with GitHub Packages)
+  pull-requests: write # Required for creating PRs
+  packages: write # Required for publishing packages
 
 jobs:
-  publish:
+  update-version:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Update version in pom.xml
+        run: |
+          VERSION=${{ github.event.release.tag_name }}
+          CLEAN_VERSION=${VERSION#v}
+          echo "VERSION=$CLEAN_VERSION" >> $GITHUB_ENV
+
+      - name: Create branch for version update
+        run: |
+          git checkout -b update-version-to-${{ env.VERSION }}
+          mvn versions:set -DnewVersion=${{ env.VERSION }}
+          git config user.name "joltbot"
+          git config user.email "joltbot@users.noreply.github.com"
+          git commit -am "Update version to ${{ env.VERSION }}"
+          git push origin update-version-to-${{ env.VERSION }}
+
+      - name: Create PR to update version
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-version-to-${{ env.VERSION }}
+          title: "Update version to ${{ env.VERSION }}"
+          body: "This PR updates the version in pom.xml to match the release version."
+          base: main
+
+  publish:
+    needs: update-version
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' # Ensure PR is merged
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Maven Central Repository
@@ -24,29 +56,10 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Set version # make assumption the release tag is in the format vX.Y.Z
+      - name: Update release tag
         run: |
-          VERSION=${{ github.event.release.tag_name }}
-          CLEAN_VERSION=${VERSION#v}
-          mvn versions:set -DnewVersion=$CLEAN_VERSION
-
-      - name: Commit version change
-        run: |
-          git config user.name "joltbot"
-          git config user.email "joltbot@users.noreply.github.com"
-          git add **/pom.xml
-          git commit -m "Update version to ${{ github.event.release.tag_name }}"
-          git push
-
-      - name: Delete existing tag # This tag was created via github release, we need to include pom.xml update, so remove it first
-        run: |
-          git tag -d ${{ github.event.release.tag_name }}
-          git push origin :refs/tags/${{ github.event.release.tag_name }}
-
-      - name: Create and push updated tag # re-create the same tag include pom.xml changes
-        run: |
-          git tag ${{ github.event.release.tag_name }}
-          git push origin ${{ github.event.release.tag_name }}
+          git tag -f ${{ github.event.release.tag_name }}
+          git push origin -f ${{ github.event.release.tag_name }}
 
       - name: Publish package
         run: mvn -P release --batch-mode deploy -DskipTests -DperformRelease=true
@@ -54,3 +67,7 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
+
+      - name: Delete version update branch
+        run: |
+          git push origin --delete update-version-to-${{ env.VERSION }}


### PR DESCRIPTION
Due to both `main` and `develop` branches are protected (can't merge directly), we need to update those release workflows.