### PR TITLE
chore(release): nvd api key also will be passed as maven property

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package
-        run: mvn -P release --batch-mode deploy -DskipTests -DperformRelease=true
+        run: mvn -P release --batch-mode deploy -DskipTests -DperformRelease=true -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>jolt-community</artifactId>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
     <name>Jolt</name>
 


### PR DESCRIPTION
1. the root pom.xml requires version tag, otherwise the update version workflow will not work as expected;
2. due to we have no configuration in maven OWASP dependency check plugin, we need to pass it via maven property.