### PR TITLE
ci: update pre-release and post-release

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,19 +13,14 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
-      - name: Checkout develop branch
+      - name: Checkout main branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: develop
-
-      - name: Reset main branch
-        run: |
-          git fetch origin main:main
-          git reset --hard main
+          ref: main
 
       - name: Create PR from main to develop
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -33,5 +28,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Merge main into develop"
           body: "This PR merges changes from main into develop."
+          base: develop
           branch: sync-main-to-develop
           delete-branch: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,19 +13,14 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
-      - name: Checkout main branch
+      - name: Checkout develop branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: main
-
-      - name: Reset develop branch
-        run: |
-          git fetch origin develop:develop
-          git reset --hard develop
+          ref: develop
 
       - name: Create PR from develop to main
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -33,5 +28,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Merge develop into main"
           body: "This PR merges changes from develop into main."
+          base: main
           branch: sync-develop-to-main
           delete-branch: true


### PR DESCRIPTION
The old `pre-release.yml` workflow uses `git reset --hard develop` on the `main` branch, which rewrites `main`'s history to match `develop`. This causes all commits unique to `develop` (including old ones) to appear in the PR, even after rebasing.

**Solution**:
Update the workflow to avoid resetting `main` to `develop`. Instead, use `peter-evans/create-pull-request` to create a PR from `develop` to `main` directly, without history rewriting. This way, only new changes (after rebase) will show up.